### PR TITLE
Converted if/elif/else block to a dictionary. PEP8 changes.

### DIFF
--- a/packages/sample/sms/__main__.py
+++ b/packages/sample/sms/__main__.py
@@ -1,11 +1,13 @@
-from http import HTTPStatus
 import os
-from twilio.rest import Client
-from twilio.base.exceptions import TwilioRestException
+from http import HTTPStatus
 
-def translateCode(code):
+from twilio.base.exceptions import TwilioRestException
+from twilio.rest import Client
+
+
+def translate_code(code):
     '''
-    Takes in the twilio status code, 
+    Takes in the twilio status code,
     returns a http status code.
 
         Parameters:
@@ -14,60 +16,41 @@ def translateCode(code):
         Returns:
             json statusCode: Json http error status code
     '''
-    if str(code) == "60000":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60001":
-        return HTTPStatus.UNAUTHORIZED
-    elif str(code) == "60002":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60003":
-        return HTTPStatus.TOO_MANY_REQUESTS
-    elif str(code) == "60004":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60005":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60021":
-        return HTTPStatus.FORBIDDEN
-    elif str(code) == "60022":
-        return HTTPStatus.UNAUTHORIZED
-    elif str(code) == "60023":
-        return HTTPStatus.NOT_FOUND
-    elif str(code) == "60033":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60042":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60046":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60060":
-        return HTTPStatus.SERVICE_UNAVAILABLE
-    elif str(code) == "60064":
-        return HTTPStatus.FORBIDDEN
-    elif str(code) == "60065":
-        return HTTPStatus.FORBIDDEN
-    elif str(code) == "60066":
-        return HTTPStatus.FORBIDDEN
-    elif str(code) == "60069":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60070":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60071":
-        return HTTPStatus.NOT_FOUND
-    elif str(code) == "60072":
-        return HTTPStatus.NOT_FOUND
-    elif str(code) == "60073":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60074":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60075":
-        return HTTPStatus.BAD_REQUEST
-    elif str(code) == "60078":
-        return HTTPStatus.FORBIDDEN
-    elif str(code) == "60082":
-        return HTTPStatus.FORBIDDEN
-    elif str(code) == "60083":
-        return HTTPStatus.FORBIDDEN
-    else:
-        return HTTPStatus.INTERNAL_SERVER_ERROR
+
+    supported_codes = {
+        60000: HTTPStatus.BAD_REQUEST,
+        60001: HTTPStatus.UNAUTHORIZED,
+        60002: HTTPStatus.BAD_REQUEST,
+        60003: HTTPStatus.TOO_MANY_REQUESTS,
+        60004: HTTPStatus.BAD_REQUEST,
+        60005: HTTPStatus.BAD_REQUEST,
+        60021: HTTPStatus.FORBIDDEN,
+        60022: HTTPStatus.UNAUTHORIZED,
+        60023: HTTPStatus.NOT_FOUND,
+        60033: HTTPStatus.BAD_REQUEST,
+        60042: HTTPStatus.BAD_REQUEST,
+        60046: HTTPStatus.BAD_REQUEST,
+        60060: HTTPStatus.SERVICE_UNAVAILABLE,
+        60064: HTTPStatus.FORBIDDEN,
+        60065: HTTPStatus.FORBIDDEN,
+        60066: HTTPStatus.FORBIDDEN,
+        60069: HTTPStatus.BAD_REQUEST,
+        60070: HTTPStatus.BAD_REQUEST,
+        60071: HTTPStatus.NOT_FOUND,
+        60072: HTTPStatus.NOT_FOUND,
+        60073: HTTPStatus.BAD_REQUEST,
+        60074: HTTPStatus.BAD_REQUEST,
+        60075: HTTPStatus.BAD_REQUEST,
+        60078: HTTPStatus.FORBIDDEN,
+        60082: HTTPStatus.FORBIDDEN,
+        60083: HTTPStatus.FORBIDDEN
+    }
+
+    if code in supported_codes:
+        return supported_codes[code]
+
+    return HTTPStatus.INTERNAL_SERVER_ERROR
+
 
 def valid_number(number, client):
     '''
@@ -80,16 +63,16 @@ def valid_number(number, client):
         Returns:
             boolean: True if valid phone number, false if invalid phone number
     '''
-    try: 
-        client.lookups.phone_numbers(number).fetch(type = "carrier")
+    try:
+        client.lookups.phone_numbers(number).fetch(type="carrier")
         return True
     except TwilioRestException as e:
-            return False
+        return False
 
 
 def main(args):
     '''
-    Takes in the phone numbers and message to send an sms using Twilio, 
+    Takes in the phone numbers and message to send an sms using Twilio,
     returns a json response letting the user know if the message sent or failed to send.
 
         Parameters:
@@ -106,38 +89,38 @@ def main(args):
 
     if not number:
         return {
-        "statusCode" : HTTPStatus.BAD_REQUEST,
-        "body" : "no number provided"
-    }
+            "statusCode": HTTPStatus.BAD_REQUEST,
+            "body": "no number provided"
+        }
     if not user_to:
         return {
-        "statusCode" : HTTPStatus.BAD_REQUEST,
-        "body" : "no receiver phone number provided"
-    }
+            "statusCode": HTTPStatus.BAD_REQUEST,
+            "body": "no receiver phone number provided"
+        }
     if not message:
         return {
-        "statusCode" : HTTPStatus.BAD_REQUEST,
-        "body" : "no message provided"
-    }
+            "statusCode": HTTPStatus.BAD_REQUEST,
+            "body": "no message provided"
+        }
 
     client = Client(sid, token)
     if valid_number(number, client) and valid_number(user_to, client):
         msg = client.messages.create(
-            body = message,
-            from_ = number,
-            to = user_to
+            body=message,
+            from_=number,
+            to=user_to
         )
         if msg.status != "undelivered" or msg.status != "failed":
             return {
-                "statusCode" : HTTPStatus.ACCEPTED,
-                "body" : "success"
-            }    
-        code = translateCode(msg.error_code)
+                "statusCode": HTTPStatus.ACCEPTED,
+                "body": "success"
+            }
+        code = translate_code(msg.error_code)
         return {
-            "statusCode" : code,
-            "body" : msg.error_message
-        }         
+            "statusCode": code,
+            "body": msg.error_message
+        }
     return {
-        "statusCode" : HTTPStatus.BAD_REQUEST,
-        "body" : "no twilio verified phone numbers provided"
+        "statusCode": HTTPStatus.BAD_REQUEST,
+        "body": "no twilio verified phone numbers provided"
     }


### PR DESCRIPTION
## Overview
Instead of using a long if/elif/else block I've converted it to use a dictionary instead. This will also give the user an option to add/remove codes easier. This keeps the code clean and easier to read/write. I've also formatted the code to PEP8 standards.

## Things done

- PEP8 changes including (but not limited to) function name changes and spacing.
- Converted the if/elif/else block to an easily extensible and readable dictionary. This also shortens the overall code line count.