### PR TITLE
Fix the result's status condition

### DIFF
--- a/packages/sample/sms/__main__.py
+++ b/packages/sample/sms/__main__.py
@@ -110,7 +110,7 @@ def main(args):
             from_=number,
             to=user_to
         )
-        if msg.status != "undelivered" or msg.status != "failed":
+        if msg.status != "undelivered" and msg.status != "failed":
             return {
                 "statusCode": HTTPStatus.ACCEPTED,
                 "body": "success"


### PR DESCRIPTION
With the original `or` the test result will always be `True`.